### PR TITLE
Feature: Enable fluent chaining of IServiceCollection

### DIFF
--- a/Helpers/IBreadcrumbsWidgetServiceExtensions.cs
+++ b/Helpers/IBreadcrumbsWidgetServiceExtensions.cs
@@ -7,7 +7,7 @@ namespace Xperience.Core.Breadcrumbs
 {
     public static class IBreadcrumbsWidgetServiceExtensions
     {
-        public static void AddBreadcrumbs(
+        public static IServiceCollection AddBreadcrumbs(
             this IServiceCollection services,
             Action<BreadcrumbsWidgetProperties> configure = null,
             IBreadcrumbsRenderer renderer = null)
@@ -28,6 +28,8 @@ namespace Xperience.Core.Breadcrumbs
                 configure(props);
             }
             services.AddSingleton(props);
+
+            return services;
         }
     }
 }


### PR DESCRIPTION
The convention for any `IServiceCollection` extensions is to return the collection so other extensions can be chained off of it.

This PR returns the collection from the extension, which was previously `void` returning.